### PR TITLE
Allows check mode run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
 - name: Check if IPv6 disabled at grub command line
   command: cat /proc/cmdline
   changed_when: false
+  check_mode: no
   ignore_errors: true
   register: cmdline
 


### PR DESCRIPTION
Initial check in main task disallowed ansible check run. The following error shows :

```
TASK [external/ipv6 : ensure ipv6 module loaded] ************************************************************************************************************************************************************************************************************************
fatal: [***]: FAILED! => {
   "msg": "The conditional check 'ansible_system == 'Linux' and not (' ipv6.disable=1' in cmdline.stdout)' failed. The error was: error while evaluating conditional (ansible_system == 'Linux' and not (' ipv6.disable=1' in cmdline.stdout)): Unable to look up a name or access an attribute in template string ({% if ansible_system == 'Linux' and not (' ipv6.disable=1' in cmdline.stdout) %} True {% else %} False {% endif %}).
Make sure your variable name does not contain invalid characters like '-': argument of type 'AnsibleUndefined' is not iterable

The error appears to be in './roles/external/ipv6/tasks/ipv6-harden.yml': line 3, column 3, but may be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: ensure ipv6 module loaded
  ^ here"}
```

Now forcing this task to run even in check mode to avoid undefined variable error.