### PR TITLE
Added missing quotation mark

### DIFF
--- a/tasks/ipv6-harden.yml
+++ b/tasks/ipv6-harden.yml
@@ -37,7 +37,7 @@
   ansible.builtin.lineinfile:
     dest: /etc/modprobe.d/blacklist.conf
     line: 'blacklist ipv6'
-    state: absent"
+    state: "absent"
   notify:
     - Modipv6
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'


### PR DESCRIPTION
fixed: `args[module]: value of state must be one of: absent, present, got: absent" (warning)`