### PR TITLE
Restarting Docker service and  Support RedHat 9 were added

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -38,3 +38,9 @@
     not (ansible_virtualization_type is defined and
           (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker")
         )
+        
+- name: Restart docker.service
+  ansible.builtin.systemd:
+    name: docker.service
+    state: restarted
+  when: ansible_facts.services['docker.service'] is defined

--- a/tasks/ipv6-disable.yml
+++ b/tasks/ipv6-disable.yml
@@ -46,6 +46,7 @@
   notify:
     - Restart network
     - Restart NetworkManager
+    - Restart docker.service
   when: ansible_os_family == 'RedHat'
 
 - name: Import ipv6-grub-disable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
-
+- name: Populate service facts
+  ansible.builtin.service_facts:
+  
 - name: Debug | ansible_distribution
   ansible.builtin.debug:
     var: ansible_distribution

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -1,0 +1,21 @@
+---
+
+ipv6_harden_settings:
+  - { n: 'net.ipv6.conf.all.forwarding', v: 0 }
+  # - { n: 'net.ipv6.conf.all.send_redirects', v: 0 }
+  - { n: 'net.ipv6.conf.all.accept_redirects', v: 0 }
+  - { n: 'net.ipv6.conf.all.accept_source_route', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_redirects', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_source_route', v: 0 }
+  - { n: 'net.ipv6.conf.default.router_solicitations', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_ra_rtr_pref', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_ra_pinfo', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_ra_defrtr', v: 0 }
+  - { n: 'net.ipv6.conf.all.accept_ra', v: 0 }
+  - { n: 'net.ipv6.conf.default.accept_ra', v: 0 }
+  - { n: 'net.ipv6.conf.default.autoconf', v: 0 }
+  - { n: 'net.ipv6.conf.default.dad_transmits', v: 0 }
+  - { n: 'net.ipv6.conf.default.max_addresses', v: 1 }
+  - { n: 'net.ipv6.conf.all.max_addresses', v: 1 }
+
+ipv6_grub_mkconfig: grub2-mkconfig


### PR DESCRIPTION
Changed: handlers/main.yml
Added: vars/RedHat-9.yml 

## Description
I have modified the handlers/main.yml file to include a Docker service restart. Additionally, I have added the vars/RedHat-9.yml file to ensure the role functions correctly on RedHat, AlmaLinux 9, and similar distributions.

## Motivation and Context
Disabling IPv6 while Docker Swarm is running necessitated a service restart.

## How Has This Been Tested?
I have verified this on multiple nodes running AlmaLinux 9.
